### PR TITLE
ci: Install explicit rust components

### DIFF
--- a/.github/workflows/build-test-run.yaml
+++ b/.github/workflows/build-test-run.yaml
@@ -29,11 +29,13 @@ jobs:
           - release
           - test
         include:
+          - components: ""
           - clippy: false
           - run: true
           - test: false
           - profile: dev
             clippy: true
+            components: clippy
           - profile: test
             run: false
             test: true
@@ -47,6 +49,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup rust tools
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1
+        with:
+          components: ${{matrix.components}}
       - name: Fetch dependencies
         run: cargo fetch --verbose --locked
       - name: Build

--- a/.github/workflows/check-rustfmt.yaml
+++ b/.github/workflows/check-rustfmt.yaml
@@ -19,5 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup rust tools
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1
+        with:
+          components: rustfmt
       - name: rustfmt
         run: cargo fmt --check


### PR DESCRIPTION
Newest rustup version in newest ubuntu-latest image in Github changed behavior. Previously rustfmt and clippy were installed by default but not anymore. This commit fixes the situation by explicitly installing those components but only when needed.